### PR TITLE
Rolled back generator version to `4.3.1`

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "5.0.1"
+    "version": "4.3.1"
   }
 }


### PR DESCRIPTION
- It seems generator `5.0.1` code templates have
  changed significantly.
- Let stick generator to `4.3.1` for release `0.5.0`
  to avoid confusion with package rename refactor.
- We shall bump generator version in next release
  for itself alone.
