### PR TITLE
Dropped Python 3.6 support

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     extras_require={
         "dev": [
             "pipdeptree",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{37,38,39,310,311}
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
* Python 3.6 has reached EOL - https://peps.python.org/pep-0494/#lifespan
* Minimum required is set to Python 3.7
* Added Python 3.10 and 3.11 to test set