### PR TITLE
Fixed OpenAPI analysisPriority value mismatch with server response

### DIFF
--- a/libica/openapi/v2/model/analysis.py
+++ b/libica/openapi/v2/model/analysis.py
@@ -74,12 +74,16 @@ class Analysis(ModelNormal):
             'FAILEDFINAL': "FAILEDFINAL",
             'ABORTED': "ABORTED",
         },
-        ('analysis_priority',): {
-            'None': None,
-            'LOW': "Low",
-            'MEDIUM': "Medium",
-            'HIGH': "High",
-        },
+        # FIXME Their OpenAPI document says expected values should be 'Low', 'Medium', 'High' and nullable
+        #  But. On the actual server, it responses with capitalised 'MEDIUM'
+        #  curl -s -H "Accept: application/vnd.illumina.v3+json" -H "Authorization: Bearer $ICAV2_ACCESS_TOKEN" "https://ica.illumina.com/ica/rest/api/projects/<project_id>/analyses/<analysis_id>" | jq
+        #  So. There is discrepancy. Since we have to accept whatever value from server, commenting out this for now.
+        # ('analysis_priority',): {
+        #     'None': None,
+        #     'LOW': "Low",
+        #     'MEDIUM': "Medium",
+        #     'HIGH': "High",
+        # },
     }
 
     validations = {

--- a/libica/openapi/v2/model/create_project.py
+++ b/libica/openapi/v2/model/create_project.py
@@ -63,12 +63,16 @@ class CreateProject(ModelNormal):
             'PROJECT': "PROJECT",
             'TENANT': "TENANT",
         },
-        ('analysis_priority',): {
-            'None': None,
-            'LOW': "Low",
-            'MEDIUM': "Medium",
-            'HIGH': "High",
-        },
+        # FIXME Their OpenAPI document says expected values should be 'Low', 'Medium', 'High' and nullable
+        #  But. On the actual server, it responses with capitalised 'MEDIUM'
+        #  curl -s -H "Accept: application/vnd.illumina.v3+json" -H "Authorization: Bearer $ICAV2_ACCESS_TOKEN" "https://ica.illumina.com/ica/rest/api/projects" | jq
+        #  So. There is discrepancy. Since we have to accept whatever value from server, commenting out this for now.
+        # ('analysis_priority',): {
+        #     'None': None,
+        #     'LOW': "Low",
+        #     'MEDIUM': "Medium",
+        #     'HIGH': "High",
+        # },
     }
 
     validations = {

--- a/libica/openapi/v2/model/project.py
+++ b/libica/openapi/v2/model/project.py
@@ -73,12 +73,16 @@ class Project(ModelNormal):
             'PROJECT': "PROJECT",
             'TENANT': "TENANT",
         },
-        ('analysis_priority',): {
-            'None': None,
-            'LOW': "Low",
-            'MEDIUM': "Medium",
-            'HIGH': "High",
-        },
+        # FIXME Their OpenAPI document says expected values should be 'Low', 'Medium', 'High' and nullable
+        #  But. On the actual server, it responses with capitalised 'MEDIUM'
+        #  curl -s -H "Accept: application/vnd.illumina.v3+json" -H "Authorization: Bearer $ICAV2_ACCESS_TOKEN" "https://ica.illumina.com/ica/rest/api/projects" | jq
+        #  So. There is discrepancy. Since we have to accept whatever value from server, commenting out this for now.
+        # ('analysis_priority',): {
+        #     'None': None,
+        #     'LOW': "Low",
+        #     'MEDIUM': "Medium",
+        #     'HIGH': "High",
+        # },
     }
 
     validations = {


### PR DESCRIPTION
* Server responses in capitalised 'MEDIUM'
* OpenAPI states expected values should be 'Low', 'Medium', 'High' and nullable
