### PR TITLE
Support Content-Disposition Config on PresignedUrl

### DIFF
--- a/examples/gds.py
+++ b/examples/gds.py
@@ -1,0 +1,27 @@
+"""
+Usage:
+    Either
+        Have your AWS_PROFILE set up and use the credentials to ICA
+    Or
+        export ICA_ACCESS_TOKEN=...
+        export ICA_BASE_URL=...
+    Then
+        python gds.py
+"""
+from libica.app import gds
+
+
+def get_gds_presigned_url():
+    is_success, val = gds.presign_gds_file(file_id="fil.{NUMBER}", volume_name="development",
+                                           path_="somePath",
+                                           presigned_url_mode="inline")
+
+    if is_success:
+        print('PresignedUrl:', val)
+
+    if not is_success:
+        print('e:', val)
+
+
+if __name__ == '__main__':
+    get_gds_presigned_url()

--- a/libica/app/gds.py
+++ b/libica/app/gds.py
@@ -178,11 +178,13 @@ def download_gds_file(volume_name: str, path: str) -> (NamedTemporaryFile, None)
     return ntf
 
 
-def presign_gds_file(file_id: str, volume_name: str, path_: str) -> (bool, str):
+def presign_gds_file(file_id: str, volume_name: str, path_: str, presigned_url_mode: str = "Attachment") -> (
+bool, str):
     with libgds.ApiClient(configuration(libgds)) as gds_client:
         files_api = libgds.FilesApi(gds_client)
         try:
-            file_details: libgds.FileResponse = files_api.get_file(file_id=file_id)
+            file_details: libgds.FileResponse = files_api.get_file(file_id=file_id,
+                                                                   presigned_url_mode=presigned_url_mode)
             return True, file_details.presigned_url
         except libgds.ApiException as e:
             message = f"Failed to sign the specified GDS file (gds://{volume_name}{path_}). Exception - {e}"


### PR DESCRIPTION
- Add `presigned_url_mode` parameter for presign GDS file.
- Default value would be `Attachment`


Link Issue: https://github.com/umccr/data-portal-apis/issues/142